### PR TITLE
Omit TOC description from markdown pages.

### DIFF
--- a/docs/how-to/FAQ.md
+++ b/docs/how-to/FAQ.md
@@ -1,7 +1,5 @@
 # Frequently Asked Question
 
-[[_TOC_]]
-
 ## When running the ADO training pipeline, the pipeline fails at the _invoke_ step. What's the error ?
 
 If you see the error below. You have to ensure that the service connection is created at the Azure Machine Learning Workspace level and not Subscription level

--- a/docs/how-to/GeneralDocumentation.md
+++ b/docs/how-to/GeneralDocumentation.md
@@ -1,7 +1,5 @@
 # General Documentation
 
-[[_TOC_]]
-
 ## Data Science Lifecycle Base Repo
 
 The base project structure was inspired by the following [dslp repo](https://github.com/dslp/dslp-repo-template). We readapted it to support minimal MLOps principles.


### PR DESCRIPTION
We don't need `[[TOC]]` description due to the latest changes on github. Please check [the similar PR](https://github.com/microsoft/dstoolkit-classification-solution-accelerator/pull/2#issuecomment-932232946) accordingly, if needed.