### PR TITLE
Update retrieve_workspace function

### DIFF
--- a/operation/execution/utils/workspace.py
+++ b/operation/execution/utils/workspace.py
@@ -27,18 +27,6 @@ def retrieve_workspace():
         print(e)
 
     try:
-        print('Trying to load worspace from subscription')
-        ws = Workspace.get(
-            name=os.environ['AMLWORKSPACE'],
-            resource_group=os.environ['RESOURCE_GROUP'],
-            subscription_id=os.environ['SUBSCRIPTION_ID']
-        )
-        return ws
-    except Exception as e:
-        print('Workspace not found.')
-        print(e)
-
-    try:
         print('Trying Service Principal')
         sp = ServicePrincipalAuthentication(
             tenant_id=os.environ['AML_TENANT_ID'],


### PR DESCRIPTION
Workspace.get and Workspace.from_config use the same interactive authentication. Though, if from_config doesn't find file during the ADO pipeline it will throw an error, which indicates that the ADO project is not well connected to AML. In the other case, the function will get stuck on interfactive authentification.