### PR TITLE
Artifact optionally separate from deployment

### DIFF
--- a/azure-pipelines/PIPELINE-1-modeling.yml
+++ b/azure-pipelines/PIPELINE-1-modeling.yml
@@ -26,16 +26,32 @@ variables:
 - ${{ if ne(variables['Build.SourceBranchName'], 'main') }}:  
     # 'develop' or feature branches: DEV environment
     - template: ../configuration/configuration-infra-DEV.variables.yml
+- name: ARTIFACT_NAME
+  value: DeploymentCode
 
 pool:
   vmImage: ubuntu-latest
 
 stages:
 
-- stage: tests
-  displayName: 'Run Code Tests'
+
+##################
+##  CODE BUILD  ##
+##################
+
+- stage: build_code
+  displayName: 'Build Code'
   jobs:
+  # Code tests
   - template: templates/run-code-tests.template.yml
+  # Generate code artifact
+  - job: build_code
+    displayName: 'Build Code'
+    steps:
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: '$(ARTIFACT_NAME)'
+          targetPath: '$(Build.SourcesDirectory)'
 
 
 ############################
@@ -44,7 +60,7 @@ stages:
 
 - stage: update_data
   displayName: 'Update Data for Training/Retraining'
-  dependsOn: tests
+  dependsOn: build_code
   jobs:
   - template: templates/update-data.template.yml
     parameters:
@@ -70,6 +86,7 @@ stages:
         serviceConnection: $(SERVICECONNECTION_WS)
         resourceGroup: $(RESOURCE_GROUP)
         amlWorkspace: $(AMLWORKSPACE)
+        artifactName: $(ARTIFACT_NAME)
         deploymentScript: operation/execution/build_training_pipeline.py
         scriptArguments: --version $(Build.BuildId)
 
@@ -101,6 +118,7 @@ stages:
       deploymentType: aci
       webserviceName: $(AML_WEBSERVICE)-aci
       deleteAfterwards: true
+      artifactName: $(ARTIFACT_NAME)
 
 
 #####################
@@ -119,3 +137,4 @@ stages:
       amlWorkspace: $(AMLWORKSPACE)
       deploymentType: aks
       webserviceName: $(AML_WEBSERVICE)
+      artifactName: $(ARTIFACT_NAME)

--- a/azure-pipelines/PIPELINE-2-batchinference.yml
+++ b/azure-pipelines/PIPELINE-2-batchinference.yml
@@ -74,6 +74,7 @@ stages:
         amlWorkspace: $(AMLWORKSPACE)
         deploymentScript: operation/execution/build_batchinference_pipeline.py
         scriptArguments: --version $(Build.BuildId)
+        createArtifact: true
 
     - template: templates/utils/invoke-aml-pipeline.template.yml
       parameters:

--- a/azure-pipelines/templates/deploy-model.template.yml
+++ b/azure-pipelines/templates/deploy-model.template.yml
@@ -19,6 +19,9 @@ parameters:
 - name: deleteAfterwards
   type: string
   default: false
+- name: artifactName
+  type: string
+  default: ''
 
 
 jobs:
@@ -44,6 +47,7 @@ jobs:
     serviceConnection: ${{parameters.serviceConnection}}
     resourceGroup: ${{parameters.resourceGroup}}
     amlWorkspace: ${{parameters.amlWorkspace}}
+    artifactName: ${{parameters.artifactName}}
     deploymentScript: operation/execution/deploy_model.py
     scriptArguments: |
       --model-name $(AML_MODEL_NAME) \

--- a/azure-pipelines/templates/run-code-tests.template.yml
+++ b/azure-pipelines/templates/run-code-tests.template.yml
@@ -4,7 +4,7 @@
 jobs:
 
 - job: 'run_unit_tests'
-  displayName: "Running unit tests"
+  displayName: "Run unit tests"
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/azure-pipelines/templates/utils/deploy-aml-endpoint.template.yml
+++ b/azure-pipelines/templates/utils/deploy-aml-endpoint.template.yml
@@ -25,22 +25,45 @@ parameters:
 - name: dependsOn
   type: object
   default: []
+- name: artifactName
+  type: string
+  default: ''
+- name: createArtifact
+  type: string
+  default: false
 
 jobs:
 
-- job: build_code
-  displayName: 'Build code to deploy'
+- job: artifact_setup
+  displayName: 'Artifact setup'
   dependsOn: ${{parameters.dependsOn}}
   steps:
 
-    - task: PublishPipelineArtifact@0
-      inputs:
-        artifactName: 'DeploymentCode'
-        targetPath: '$(Build.SourcesDirectory)'
+    - bash: |
+        if [ "${{parameters.artifactName}}" == "" ]; then
+          artifact_name='DeploymentCodeInternalArtifact'
+        else
+          artifact_name=${{parameters.artifactName}}
+        fi
+        echo "Artifact name: $artifact_name"
+        echo "##vso[task.setvariable variable=artifact_name;isOutput=true;]$artifact_name"
+      name: set_artifact_name
+      displayName: 'Set artifact name'
+      failOnStderr: true
+
+    - ${{ if eq(parameters.createArtifact, 'true') }}:
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: '$(set_artifact_name.artifact_name)'
+          targetPath: '$(Build.SourcesDirectory)'
+        name: build_code
+        displayName: 'Build code to deploy'
 
 - deployment: ${{parameters.jobName}}
   displayName: ${{parameters.jobDisplayName}}
-  dependsOn: build_code
+  dependsOn: artifact_setup
+  variables:
+      artifact_name: $[ dependencies.artifact_setup.outputs['set_artifact_name.artifact_name'] ]
   pool:
     vmImage: 'ubuntu-latest'
   environment: ${{parameters.environment}}
@@ -52,7 +75,7 @@ jobs:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download deployment code'
             inputs:
-              artifact: 'DeploymentCode'
+              artifact: '$(ARTIFACT_NAME)'
               path: $(System.ArtifactsDirectory)/deploymentcode/
 
           - template: run-aml-python-code.template.yml


### PR DESCRIPTION
Closes #39.
Modified `deploy-aml-endpoint.template.yml` to make creation of code artifact optional, accepting an `artifactName` from outside. Adapted pipelines 1 & 2 consequently (in modeling pipeline, artifact is generated at the beginning to fix the issue).