### PR TITLE
Change default auth method from pipelines to Service Principal

### DIFF
--- a/azure-pipelines/PIPELINE-0-setup.yml
+++ b/azure-pipelines/PIPELINE-0-setup.yml
@@ -24,7 +24,7 @@ variables:
 - template: ../configuration/configuration-infra-DEV.variables.yml # DEV as default env
 
 pool:
-  vmImage: ubuntu-18.04
+  vmImage: $(VM_VERSION)
 
 stages:
 

--- a/azure-pipelines/PIPELINE-1-modeling.yml
+++ b/azure-pipelines/PIPELINE-1-modeling.yml
@@ -30,7 +30,7 @@ variables:
   value: DeploymentCode
 
 pool:
-  vmImage: ubuntu-18.04
+  vmImage: $(VM_VERSION)
 
 stages:
 

--- a/azure-pipelines/PIPELINE-2-batchinference.yml
+++ b/azure-pipelines/PIPELINE-2-batchinference.yml
@@ -28,7 +28,7 @@ variables:
     - template: ../configuration/configuration-infra-DEV.variables.yml
 
 pool:
-  vmImage: ubuntu-18.04
+  vmImage: $(VM_VERSION)
 
 stages:
 

--- a/azure-pipelines/templates/utils/deploy-aml-endpoint.template.yml
+++ b/azure-pipelines/templates/utils/deploy-aml-endpoint.template.yml
@@ -65,7 +65,7 @@ jobs:
   variables:
       artifact_name: $[ dependencies.artifact_setup.outputs['set_artifact_name.artifact_name'] ]
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: $(VM_VERSION)
   environment: ${{parameters.environment}}
   strategy:
     runOnce:

--- a/azure-pipelines/templates/utils/run-aml-python-code.template.yml
+++ b/azure-pipelines/templates/utils/run-aml-python-code.template.yml
@@ -28,28 +28,6 @@ steps:
       displayName: 'Use Python $(PYTHON_VERSION)'
       inputs:
         versionSpec: $(PYTHON_VERSION)
-    # TODO: temporary fixed for bug in az cli 2.30 is corrected
-    # Downgrade azure-devops 0.21.0 due to this error: https://github.com/microsoft/dstoolkit-mlops-base/issues/47
-    - task: AzureCLI@1
-      displayName: 'Downgrade azure-devops 0.21.0'
-      inputs:
-        azureSubscription: ${{parameters.serviceConnection}}
-        scriptLocation: inlineScript
-        inlineScript: |
-          az extension remove --name azure-devops
-          az extension add --name azure-devops --version 0.21.0
-
-    # Downgrade az cli due to this error: https://github.com/microsoft/dstoolkit-mlops-base/issues/47
-    - task: Bash@3
-      displayName: "Bash: Downgrade AZ CLI to [2.29.2]"
-      inputs:
-        targetType: "inline"
-        workingDirectory: "$(Build.SourcesDirectory)"
-        script: |
-          sudo add-apt-repository https://packages.microsoft.com/repos/azure-cli
-          sudo apt update
-          apt-cache policy azure-cli
-          sudo apt install -y --allow-downgrades azure-cli=2.29.2-1~bionic
 
     - task: AzureCLI@1
       displayName: 'Generate AML Workspace Config File'
@@ -70,6 +48,7 @@ steps:
       inputs:
         azureSubscription: ${{parameters.serviceConnection}}
         scriptLocation: inlineScript
+        addSpnToEnvironment: true  # Creates env vars: servicePrincipalId, servicePrincipalKey, tenantId
         inlineScript: |
           dependencies="azureml-sdk==$(SDK_VERSION) ${{parameters.scriptExtraDependencies}}"
           python -m pip install --upgrade pip && python -m pip install $dependencies

--- a/configuration/configuration-aml.variables.yml
+++ b/configuration/configuration-aml.variables.yml
@@ -7,6 +7,7 @@ variables:
 
   PYTHON_VERSION: 3.8
   SDK_VERSION: 1.35
+  VM_VERSION: ubuntu-18.04
 
   AML_DATASET: mydataset
   AML_MODEL_NAME: mymodel

--- a/operation/execution/utils/workspace.py
+++ b/operation/execution/utils/workspace.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from azureml.core import Workspace
-from azureml.core.authentication import ServicePrincipalAuthentication
+from azureml.core.authentication import ServicePrincipalAuthentication, InteractiveLoginAuthentication
 
 
 def retrieve_workspace():
@@ -19,41 +19,36 @@ def retrieve_workspace():
 
     """
 
+    # Choose propper authentication method
+    if os.environ.get("servicePrincipalId"):  # From AzureCLI DevOps task
+        auth = ServicePrincipalAuthentication(
+            tenant_id=os.environ.get("tenantId"),
+            service_principal_id=os.environ.get("servicePrincipalId"),
+            service_principal_password=os.environ.get("servicePrincipalKey")
+        )
+    elif os.environ.get("tenantId"):
+        auth = InteractiveLoginAuthentication(tenant_id=os.environ.get("tenantId"))
+    else:
+        auth = None
+
     try:
-        ws = Workspace.from_config()
+        ws = Workspace.from_config(auth=auth)
         return ws
     except Exception as e:
         print('Workspace could not be loaded from config file.')
         print(e)
 
     try:
-        print('Trying to load worspace from subscription')
+        print('Trying to load workspace from name')
         ws = Workspace.get(
             name=os.environ['AMLWORKSPACE'],
             resource_group=os.environ['RESOURCE_GROUP'],
-            subscription_id=os.environ['SUBSCRIPTION_ID']
+            subscription_id=os.environ['SUBSCRIPTION_ID'],
+            auth=auth
         )
         return ws
     except Exception as e:
         print('Workspace not found.')
         print(e)
 
-    try:
-        print('Trying Service Principal')
-        sp = ServicePrincipalAuthentication(
-            tenant_id=os.environ['AML_TENANT_ID'],
-            service_principal_id=os.environ['AML_PRINCIPAL_ID'],
-            service_principal_password=os.environ['AML_PRINCIPAL_PASS']
-            )
-        ws = Workspace.get(
-            name=os.environ['AMLWORKSPACE'],
-            auth=sp,
-            subscription_id=os.environ['SUBSCRIPTION_ID']
-        )
-        return ws
-    except Exception as e:
-        print('Connection via SP failed:', e)
-
-    print('Error - Workspace not found')
-    print('Error - Shuting everything down.')
-    sys.exit(-1)
+    raise RuntimeError('Error - Workspace not found')

--- a/operation/execution/utils/workspace.py
+++ b/operation/execution/utils/workspace.py
@@ -21,17 +21,20 @@ def retrieve_workspace():
 
     # Choose propper authentication method
     if os.environ.get("servicePrincipalId"):  # From AzureCLI DevOps task
+        print('Using Service Principal authentication')
         auth = ServicePrincipalAuthentication(
             tenant_id=os.environ.get("tenantId"),
             service_principal_id=os.environ.get("servicePrincipalId"),
             service_principal_password=os.environ.get("servicePrincipalKey")
         )
     elif os.environ.get("tenantId"):
+        print('Using Interactive Login authentication')
         auth = InteractiveLoginAuthentication(tenant_id=os.environ.get("tenantId"))
     else:
         auth = None
 
     try:
+        print('Trying to load workspace from config file')
         ws = Workspace.from_config(auth=auth)
         return ws
     except Exception as e:

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,7 +7,6 @@ import sys
 import joblib
 import pandas as pd
 from azureml.core import Run, Dataset, Workspace, Model
-from azureml.core.authentication import ServicePrincipalAuthentication
 from azureml.core.run import _OfflineRun
 
 
@@ -27,20 +26,6 @@ def retrieve_workspace() -> Workspace:
         return ws
     except Exception as ex:
         print('Workspace config not found in local folder', ex)
-
-    try:
-        sp = ServicePrincipalAuthentication(
-            tenant_id=os.environ['AML_TENANT_ID'],
-            service_principal_id=os.environ['AML_PRINCIPAL_ID'],
-            service_principal_password=os.environ['AML_PRINCIPAL_PASS']
-        )
-        ws = Workspace.get(
-            name="<ml-example>",
-            auth=sp,
-            subscription_id="<your-sub-id>"
-        )
-    except Exception as ex:
-        print('Workspace config not found in project', ex)
 
     return ws
 


### PR DESCRIPTION
Closes #52

- Refactored **operation**'s `retrieve_workspace()` to first pick best auth option based on env vars defined and then pick workspace retrieval method (try config file first, then by name).
- Removed SP auth option from **src**'s `retrieve_workspace()` - we were not using it.
- Also defined `VM_VERSION` var in aml vars yaml file to pin ubuntu version as we are doing with the Python & SDK versions.
