### PR TITLE
Revert "Handle Multiple Models in deployment"

### DIFF
--- a/azure-pipelines/templates/deploy-model.template.yml
+++ b/azure-pipelines/templates/deploy-model.template.yml
@@ -50,7 +50,7 @@ jobs:
     artifactName: ${{parameters.artifactName}}
     deploymentScript: operation/execution/deploy_model.py
     scriptArguments: |
-      --model-names $(AML_MODELS) \
+      --model-name $(AML_MODEL_NAME) \
       --config-path configuration/compute/${{parameters.environment}}-realtimeinference-webservice-${{parameters.deploymentType}}.yml \
       --env-path $(AML_REALTIMEINFERENCE_ENV_PATH) \
       --service-name ${{parameters.webserviceName}} \

--- a/configuration/configuration-aml.variables.yml
+++ b/configuration/configuration-aml.variables.yml
@@ -30,4 +30,3 @@ variables:
   AML_REALTIMEINFERENCE_ENV_PATH: $(AML_BATCHINFERENCE_ENV_PATH)
   AKS_COMPUTE: aks-compute
   AML_WEBSERVICE: webservice
-  AML_MODELS: '[\"$(AML_MODEL_NAME)\",\"some-other-model\"]'

--- a/operation/execution/deploy_model.py
+++ b/operation/execution/deploy_model.py
@@ -7,16 +7,11 @@ from azureml.core import Model
 
 from aml_utils import config, workspace, deployment
 
-import json
 
-
-def main(model_names, service_name, compute_config_file, environment_path, aks_target_name=None):
+def main(model_name, service_name, compute_config_file, environment_path, aks_target_name=None):
 
     ws = workspace.retrieve_workspace()
-    models = []
-    for name in model_names:
-        models.append(Model(ws, name=name))
-        print(f"model_name: {name}")
+    model = Model(ws, name=model_name)  # TODO: support for more than 1 model?
 
     # Get repo root path, every other path will be relative to this
     base_path = config.get_root_path()
@@ -37,7 +32,7 @@ def main(model_names, service_name, compute_config_file, environment_path, aks_t
     service = deployment.launch_deployment(
         ws,
         service_name=service_name,
-        models=models,
+        models=[model],
         deployment_params=deployment_params
     )
     print(f'Waiting for deployment of {service.name} to finish...')
@@ -46,7 +41,7 @@ def main(model_names, service_name, compute_config_file, environment_path, aks_t
 
 def parse_args(args_list=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model-names', type=json.loads, required=True)
+    parser.add_argument('--model-name', type=str, required=True)
     parser.add_argument('--config-path', type=str, required=True)
     parser.add_argument('--env-path', type=str, required=True)
     parser.add_argument('--service-name', type=str, default='webservice')
@@ -58,7 +53,7 @@ if __name__ == "__main__":
     args = parse_args()
 
     main(
-        model_name=args.model_names,
+        model_name=args.model_name,
         service_name=args.service_name,
         compute_config_file=args.config_path,
         environment_path=args.env_path,


### PR DESCRIPTION
Reverts microsoft/dstoolkit-mlops-base#61

The scoring.py currently supports only one model. It is needed to change too.